### PR TITLE
Implement MOEX analytics support

### DIFF
--- a/src/main/kotlin/data/market/MoexDataSource.kt
+++ b/src/main/kotlin/data/market/MoexDataSource.kt
@@ -1,27 +1,40 @@
 package data.market
 
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import java.time.LocalDate
 
 class MoexDataSource(
      val repository: MoexRepository,
 ) {
-    suspend fun fetchMarketData(): MarketData {
+    suspend fun fetchMarketData(): MarketData = coroutineScope {
         val today = LocalDate.now()
         val from = today.minusDays(365)
-        val closes = mutableListOf<Double>()
-        val highs = mutableListOf<Double>()
-        var start = 0
-        var total: Int
-        var pageSize: Int
-        do {
-            val root = repository.fetchPage(from, today, start)
-            val page = MarketDataSerializer.parsePage(root)
-            closes += page.closes
-            highs += page.highs
-            total = page.total
-            pageSize = page.pageSize
-            start += pageSize
-        } while (start < total)
-        return MarketDataSerializer.toMarketData(closes, highs)
+
+        val historyDef = async {
+            val closes = mutableListOf<Double>()
+            val highs = mutableListOf<Double>()
+            var start = 0
+            var total: Int
+            var pageSize: Int
+            do {
+                val root = repository.fetchPage(from, today, start)
+                val page = MarketDataSerializer.parsePage(root)
+                closes += page.closes
+                highs += page.highs
+                total = page.total
+                pageSize = page.pageSize
+                start += pageSize
+            } while (start < total)
+            closes to highs
+        }
+
+        val analyticsDef = async { MarketDataSerializer.parseAnalytics(repository.fetchAnalytics()) }
+        val zcycDef = async { MarketDataSerializer.parseZcyc(repository.fetchZcyc(from, today)) }
+
+        val (closes, highs) = historyDef.await()
+        val (pe, dy) = analyticsDef.await()
+        val ofz = zcycDef.await()
+        MarketDataSerializer.toMarketData(closes, highs, pe, dy, ofz)
     }
 }

--- a/src/main/kotlin/data/market/MoexRepository.kt
+++ b/src/main/kotlin/data/market/MoexRepository.kt
@@ -30,6 +30,26 @@ class MoexRepository(
         makeRequest(url)
     }
 
+    suspend fun fetchAnalytics(): JsonObject = withContext(Dispatchers.IO) {
+        val url = "$baseUrl/engines/stock/markets/index/securities/IMOEX.json".toHttpUrlOrNull()!!
+            .newBuilder()
+            .addQueryParameter("iss.meta", "off")
+            .addQueryParameter("iss.only", "analytics")
+            .build()
+        makeRequest(url)
+    }
+
+    suspend fun fetchZcyc(from: LocalDate, till: LocalDate): JsonObject = withContext(Dispatchers.IO) {
+        val url = "$baseUrl/engines/stock/markets/zcyc.json".toHttpUrlOrNull()!!
+            .newBuilder()
+            .addQueryParameter("iss.meta", "off")
+            .addQueryParameter("iss.only", "zcyc")
+            .addQueryParameter("from", from.toString())
+            .addQueryParameter("till", till.toString())
+            .build()
+        makeRequest(url)
+    }
+
     private fun makeRequest(url: HttpUrl): JsonObject {
         val req = Request.Builder().url(url).build()
         client.newCall(req).execute().use { res ->

--- a/src/test/kotlin/MoexClientTest.kt
+++ b/src/test/kotlin/MoexClientTest.kt
@@ -1,11 +1,10 @@
 package org.example
 
-import data.market.MoexDataSource
-import data.market.MoexRepository
 import kotlinx.coroutines.runBlocking
-import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
 import org.example.di.AppModule
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
@@ -15,7 +14,18 @@ class MoexClientTest {
     fun `parse market data`() = runBlocking {
         val server  = MockWebServer()
         val history = javaClass.getResource("/history.json")!!.readText()
-        server.enqueue(MockResponse().setBody(history))
+        val analytics = javaClass.getResource("/analytics.json")!!.readText()
+        val zcyc = javaClass.getResource("/zcyc.json")!!.readText()
+        server.dispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse {
+                return when {
+                    request.path!!.contains("/history/engines/stock/markets/index/securities/IMOEX.json") -> MockResponse().setBody(history)
+                    request.path!!.contains("/engines/stock/markets/index/securities/IMOEX.json") -> MockResponse().setBody(analytics)
+                    request.path!!.contains("/engines/stock/markets/zcyc.json") -> MockResponse().setBody(zcyc)
+                    else -> MockResponse().setResponseCode(404)
+                }
+            }
+        }
         server.start()
         System.setProperty("moex.base", server.url("/").toString().removeSuffix("/"))
 
@@ -24,5 +34,8 @@ class MoexClientTest {
         server.shutdown()
         assertEquals(2786.16, data.price)
         assertEquals(3371.06, data.max52)
+        assertEquals(5.7, data.pe)
+        assertEquals(7.5, data.dy)
+        assertEquals(15.30, data.ofzYield)
     }
 }

--- a/src/test/kotlin/StrategyTest.kt
+++ b/src/test/kotlin/StrategyTest.kt
@@ -1,5 +1,5 @@
 import org.example.Strategy
-import org.example.MarketData
+import data.market.MarketData
 import org.example.Portfolio
 import org.example.StrategyConfig
 import org.example.Action

--- a/src/test/resources/analytics.json
+++ b/src/test/resources/analytics.json
@@ -1,0 +1,8 @@
+{
+  "analytics": {
+    "columns": ["SECID", "P/E", "YIELD"],
+    "data": [
+      ["IMOEX", 5.7, 7.5]
+    ]
+  }
+}

--- a/src/test/resources/zcyc.json
+++ b/src/test/resources/zcyc.json
@@ -1,0 +1,8 @@
+{
+  "zcyc": {
+    "columns": ["TRADEDATE", "MATURITY", "YIELD"],
+    "data": [
+      ["2025-06-06", "2035-06-06", 15.30]
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add parsing for analytics and zcyc blocks
- fetch analytics and OFZ yield concurrently
- extend repository to call new endpoints
- adjust client tests to cover P/E, dividend yield and OFZ yield
- fix StrategyTest imports

## Testing
- `./gradlew test`
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_6846a139466083228a0f905d4d593997