### PR TITLE
Use Retrofit for Moex client

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,8 @@ repositories {
 
 dependencies {
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
+    implementation("com.squareup.retrofit2:retrofit:3.0.0")
+    implementation("com.squareup.retrofit2:converter-kotlinx-serialization:3.0.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
     implementation("org.slf4j:slf4j-api:1.7.36")

--- a/src/test/kotlin/MarketDataSerializerTest.kt
+++ b/src/test/kotlin/MarketDataSerializerTest.kt
@@ -1,5 +1,6 @@
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.jsonObject
+import data.market.MarketPageResponse
+import kotlinx.serialization.decodeFromString
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -13,7 +14,7 @@ class MarketDataSerializerTest {
 
     @Test
     fun parsePage() {
-        val root = json.parseToJsonElement(loadHistory()).jsonObject
+        val root = json.decodeFromString<MarketPageResponse>(loadHistory())
         val page = MarketDataSerializer.parsePage(root)
         assertEquals(256, page.closes.size)
         assertEquals(3192.38, page.closes.first())
@@ -24,7 +25,7 @@ class MarketDataSerializerTest {
 
     @Test
     fun toMarketData() {
-        val root = json.parseToJsonElement(loadHistory()).jsonObject
+        val root = json.decodeFromString<MarketPageResponse>(loadHistory())
         val page = MarketDataSerializer.parsePage(root)
         val data = MarketDataSerializer.toMarketData(page.closes, page.highs)
         assertEquals(2786.16, data.price)


### PR DESCRIPTION
## Summary
- migrate MoexRepository to Retrofit service
- parse MOEX responses via Kotlin serialization
- update MarketDataSerializer to handle Retrofit DTO
- update unit tests
- add Retrofit dependencies

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_6846a47b9d348322a6ce6a5382d4510c