### PR TITLE
Add Spring WebApp backend integrated with bot

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,3 +18,7 @@ tasks.named("build") {
 subprojects {
     repositories { mavenCentral() }
 }
+
+application {
+    mainClass.set("app.MainKt")
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,4 +4,4 @@ plugins {
 
 rootProject.name = "StockCalculator"
 
-include("data", "service", "cli", "telegram", "app")
+include("data", "service", "cli", "telegram", "webapp", "app")

--- a/telegram/build.gradle.kts
+++ b/telegram/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 dependencies {
     implementation(project(":service"))
     implementation(project(":data"))
+    implementation(project(":webapp"))
     implementation("org.telegram:telegrambots:6.9.7.1")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
     implementation("io.insert-koin:koin-core:3.5.3")

--- a/telegram/src/main/kotlin/bot/BotCommandHandler.kt
+++ b/telegram/src/main/kotlin/bot/BotCommandHandler.kt
@@ -10,62 +10,70 @@ import java.time.LocalTime
 class BotCommandHandler(
     private val repository: ChatConfigRepository,
     private val dcaService: DcaService,
+    private val webAppUrl: String,
 ) {
     suspend fun handle(
         chatId: Long,
         text: String,
         portfolio: Portfolio,
         date: LocalDate = LocalDate.now(),
-    ): String {
+    ): BotResponse {
         val parts = text.trim().split(Regex("\\s+"))
-        val command = parts.firstOrNull() ?: return ""
+        val command = parts.firstOrNull() ?: return TextResponse("")
         val arg = parts.getOrNull(1)
         val config = repository.getConfig(chatId)
         return when (command) {
             "/set_monthly_flow" -> {
-                val value = arg?.toDoubleOrNull() ?: return "Неверный формат"
-                if (value <= 0) return "Значение должно быть положительным"
+                val value = arg?.toDoubleOrNull() ?: return TextResponse("Неверный формат")
+                if (value <= 0) return TextResponse("Значение должно быть положительным")
                 config.monthlyFlow = value
                 repository.update(chatId, config)
-                "Monthly flow установлен: ${value.toLong()}"
+                TextResponse("Monthly flow установлен: ${value.toLong()}")
             }
             "/set_base_dca" -> {
-                val value = arg?.toDoubleOrNull() ?: return "Неверный формат"
-                if (value <= 0 || value > config.monthlyFlow) return "Значение должно быть положительным и ≤ monthly flow"
+                val value = arg?.toDoubleOrNull() ?: return TextResponse("Неверный формат")
+                if (value <= 0 || value > config.monthlyFlow) return TextResponse("Значение должно быть положительным и ≤ monthly flow")
                 config.baseDcaAmount = value
                 repository.update(chatId, config)
-                "Base DCA установлен: ${value.toLong()}"
+                TextResponse("Base DCA установлен: ${value.toLong()}")
             }
             "/set_min_cushion_ratio" -> {
-                val value = arg?.toDoubleOrNull() ?: return "Неверный формат"
-                if (value < 1.0) return "Значение должно быть ≥ 1"
+                val value = arg?.toDoubleOrNull() ?: return TextResponse("Неверный формат")
+                if (value < 1.0) return TextResponse("Значение должно быть ≥ 1")
                 config.minCushionRatio = value
                 repository.update(chatId, config)
-                "Min cushion ratio = $value"
+                TextResponse("Min cushion ratio = $value")
             }
             "/set_report_time" -> {
                 val time =
                     try {
                         LocalTime.parse(arg)
                     } catch (_: Exception) {
-                        return "Неверный формат времени"
+                        return TextResponse("Неверный формат времени")
                     }
                 config.reportTime = time
                 repository.update(chatId, config)
-                "Report time установлен: $time"
+                TextResponse("Report time установлен: $time")
             }
             "/show_config" -> {
-                """
+                TextResponse(
+                    """
                 MONTHLY_FLOW=${config.monthlyFlow.toLong()}
 BASE_DCA=${config.baseDcaAmount.toLong()}
 MIN_CUSHION_RATIO=${config.minCushionRatio}
 REPORT_TIME=${config.reportTime}
-                """.trimIndent()
+                """.trimIndent(),
+                )
             }
             "/report_now" -> {
-                dcaService.generateReport(date, portfolio, config.toStrategyConfig())
+                TextResponse(
+                    dcaService.generateReport(date, portfolio, config.toStrategyConfig()),
+                )
             }
-            else -> "Неизвестная команда"
+            "/open_webapp" -> {
+                WebAppResponse(webAppUrl)
+            }
+            else -> TextResponse("Неизвестная команда")
         }
     }
 }

--- a/telegram/src/main/kotlin/bot/BotResponse.kt
+++ b/telegram/src/main/kotlin/bot/BotResponse.kt
@@ -1,0 +1,7 @@
+package bot
+
+sealed interface BotResponse
+
+data class TextResponse(val text: String) : BotResponse
+
+data class WebAppResponse(val url: String) : BotResponse

--- a/telegram/src/main/kotlin/bot/TelegramBot.kt
+++ b/telegram/src/main/kotlin/bot/TelegramBot.kt
@@ -3,6 +3,9 @@ package bot
 import kotlinx.coroutines.runBlocking
 import org.telegram.telegrambots.bots.TelegramLongPollingBot
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardButton
+import org.telegram.telegrambots.meta.api.objects.webapp.WebAppInfo
 import org.telegram.telegrambots.meta.api.objects.Update
 import service.dto.Portfolio
 
@@ -24,7 +27,18 @@ class TelegramBot(
                 runBlocking {
                     handler.handle(chatId, text, portfolioProvider())
                 }
-            val message = SendMessage(chatId.toString(), response)
+            val message = when (response) {
+                is TextResponse -> SendMessage(chatId.toString(), response.text)
+                is WebAppResponse -> {
+                    val button =
+                        InlineKeyboardButton("Open WebApp").apply {
+                            webApp = WebAppInfo(response.url)
+                        }
+                    SendMessage(chatId.toString(), "Запустить WebApp").apply {
+                        replyMarkup = InlineKeyboardMarkup(listOf(listOf(button)))
+                    }
+                }
+            }
             execute(message)
         }
     }

--- a/telegram/src/main/kotlin/bot/TelegramModule.kt
+++ b/telegram/src/main/kotlin/bot/TelegramModule.kt
@@ -13,6 +13,7 @@ val telegramModule =
         ) {
             val token = System.getenv("TELEGRAM_BOT_TOKEN") ?: error("TELEGRAM_BOT_TOKEN not set")
             val username = System.getenv("TELEGRAM_BOT_USERNAME") ?: "StockBot"
-            TelegramRunner(token, username) { Portfolio(700_000.0, 300_000.0, 300_000.0) }
+            val webAppUrl = System.getenv("WEBAPP_URL") ?: "http://localhost:8080"
+            TelegramRunner(token, username, webAppUrl) { Portfolio(700_000.0, 300_000.0, 300_000.0) }
         }
     }

--- a/telegram/src/main/kotlin/bot/TelegramRunner.kt
+++ b/telegram/src/main/kotlin/bot/TelegramRunner.kt
@@ -7,6 +7,7 @@ import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import org.telegram.telegrambots.meta.TelegramBotsApi
 import org.telegram.telegrambots.updatesreceivers.DefaultBotSession
+import webapp.startWebApp
 import service.DcaService
 import service.di.Runner
 import service.dto.Portfolio
@@ -14,6 +15,7 @@ import service.dto.Portfolio
 class TelegramRunner(
     private val token: String,
     private val username: String,
+    private val webAppUrl: String,
     private val portfolioProvider: () -> Portfolio,
 ) : Runner,
     KoinComponent {
@@ -21,7 +23,8 @@ class TelegramRunner(
     private val service: DcaService by inject()
 
     override fun run(chatId: Long?) {
-        val handler = BotCommandHandler(repository, service)
+        val handler = BotCommandHandler(repository, service, webAppUrl)
+        startWebApp()
         val bot = TelegramBot(token, username, handler, portfolioProvider)
         val api = TelegramBotsApi(DefaultBotSession::class.java)
         api.registerBot(bot)

--- a/telegram/src/test/kotlin/BotCommandHandlerTest.kt
+++ b/telegram/src/test/kotlin/BotCommandHandlerTest.kt
@@ -1,4 +1,6 @@
 import bot.BotCommandHandler
+import bot.TextResponse
+import bot.WebAppResponse
 import data.InMemoryChatConfigRepository
 import data.market.MarketData
 import kotlinx.coroutines.runBlocking
@@ -14,7 +16,7 @@ class BotCommandHandlerTest {
         runBlocking {
             val repo = InMemoryChatConfigRepository()
             val ds = DcaService { MarketData(1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0) }
-            val handler = BotCommandHandler(repo, ds)
+            val handler = BotCommandHandler(repo, ds, "http://localhost")
             val portfolio = Portfolio(0.0, 0.0, 0.0)
             handler.handle(1, "/set_monthly_flow 150000", portfolio)
             assertEquals(150_000.0, repo.getConfig(1).monthlyFlow)
@@ -26,9 +28,19 @@ class BotCommandHandlerTest {
             val repo = InMemoryChatConfigRepository()
             val md = MarketData(2650.0, 3000.0, 2700.0, 28.0, 6.3, 13.0, 10.5)
             val ds = DcaService { md }
-            val handler = BotCommandHandler(repo, ds)
+            val handler = BotCommandHandler(repo, ds, "http://localhost")
             val portfolio = Portfolio(700_000.0, 300_000.0, 300_000.0)
-            val text = handler.handle(1, "/report_now", portfolio)
-            assertTrue(text.contains("price="))
+            val text = handler.handle(1, "/report_now", portfolio) as TextResponse
+            assertTrue(text.text.contains("price="))
+        }
+
+    @Test
+    fun `open webapp returns webapp response`() = runBlocking {
+        val repo = InMemoryChatConfigRepository()
+        val ds = DcaService { MarketData(1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0) }
+        val handler = BotCommandHandler(repo, ds, "http://localhost")
+        val portfolio = Portfolio(0.0, 0.0, 0.0)
+        val resp = handler.handle(1, "/open_webapp", portfolio)
+        assertTrue(resp is WebAppResponse)
         }
 }

--- a/webapp/build.gradle.kts
+++ b/webapp/build.gradle.kts
@@ -1,0 +1,10 @@
+plugins {
+    kotlin("jvm")
+}
+
+dependencies {
+    implementation(project(":service"))
+    implementation("org.springframework.boot:spring-boot-starter-web:3.2.0")
+    testImplementation("org.springframework.boot:spring-boot-starter-test:3.2.0")
+    testImplementation(kotlin("test"))
+}

--- a/webapp/src/main/kotlin/webapp/EchoController.kt
+++ b/webapp/src/main/kotlin/webapp/EchoController.kt
@@ -1,0 +1,11 @@
+package webapp
+
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class EchoController {
+    @GetMapping("/api/echo")
+    fun echo(@RequestParam text: String): String = text
+}

--- a/webapp/src/main/kotlin/webapp/WebApp.kt
+++ b/webapp/src/main/kotlin/webapp/WebApp.kt
@@ -1,0 +1,11 @@
+package webapp
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+@SpringBootApplication
+open class WebApp
+
+fun startWebApp() {
+    runApplication<WebApp>()
+}

--- a/webapp/src/test/kotlin/webapp/EchoControllerTest.kt
+++ b/webapp/src/test/kotlin/webapp/EchoControllerTest.kt
@@ -1,0 +1,21 @@
+package webapp
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.http.HttpStatus
+import kotlin.test.assertEquals
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class EchoControllerTest {
+    @Autowired
+    lateinit var rest: TestRestTemplate
+
+    @Test
+    fun echoReturnsText() {
+        val response = rest.getForEntity("/api/echo?text=hi", String::class.java)
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertEquals("hi", response.body)
+    }
+}


### PR DESCRIPTION
## Summary
- add Spring `webapp` module with simple echo endpoint
- add command `/open_webapp` returning inline button
- start webapp together with Telegram bot
- update DI module and tests

## Testing
- `./gradlew test`
- `./gradlew build`
- `TELEGRAM_BOT_TOKEN=dummy ./gradlew :app:run --args="bot"` *(fails to reach Telegram but starts Spring server)*

------
https://chatgpt.com/codex/tasks/task_e_684742570a948322b16d022280480790