### PR TITLE
Implement risk corridor using macro data

### DIFF
--- a/data/src/main/kotlin/DataModule.kt
+++ b/data/src/main/kotlin/DataModule.kt
@@ -2,6 +2,9 @@ package data
 
 import data.market.MoexDataSource
 import data.market.MoexRepository
+import data.macro.BrentDataSource
+import data.macro.KeyRateDataSource
+import data.macro.MacroDataSource
 import kotlinx.serialization.json.Json
 import okhttp3.OkHttpClient
 import org.koin.dsl.module
@@ -16,5 +19,8 @@ val dataModule = module {
     single { Json { ignoreUnknownKeys = true } }
     single { MoexRepository(get(), get()) }
     single { MoexDataSource(get()) }
+    single { BrentDataSource(get()) }
+    single { KeyRateDataSource(get()) }
+    single { MacroDataSource(get(), get()) }
     single<ChatConfigRepository> { InMemoryChatConfigRepository() }
 }

--- a/data/src/main/kotlin/data/macro/BrentDataSource.kt
+++ b/data/src/main/kotlin/data/macro/BrentDataSource.kt
@@ -1,0 +1,16 @@
+package data.macro
+
+import okhttp3.OkHttpClient
+
+class BrentDataSource(private val client: OkHttpClient) {
+    suspend fun fetchBrentPrice(): Double {
+        val url = "https://raw.githubusercontent.com/datasets/oil-prices/master/data/brent-daily.csv"
+        val request = okhttp3.Request.Builder().url(url).build()
+        client.newCall(request).execute().use { resp ->
+            val body = resp.body?.string() ?: error("empty body")
+            val line = body.trim().lineSequence().last()
+            val price = line.substringAfter(',')
+            return price.toDouble()
+        }
+    }
+}

--- a/data/src/main/kotlin/data/macro/KeyRateDataSource.kt
+++ b/data/src/main/kotlin/data/macro/KeyRateDataSource.kt
@@ -1,0 +1,30 @@
+package data.macro
+
+import okhttp3.OkHttpClient
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+class KeyRateDataSource(private val client: OkHttpClient) {
+    private val formatter = DateTimeFormatter.ofPattern("dd.MM.yyyy")
+
+    suspend fun fetchKeyRates(date: LocalDate): Pair<Double, Double> {
+        val from = date.minusMonths(6)
+        val url =
+            "https://www.cbr.ru/eng/hd_base/KeyRate/?UniDbQuery.Posted=True&" +
+                "UniDbQuery.From=${from.format(formatter)}&" +
+                "UniDbQuery.To=${date.format(formatter)}"
+        val request = okhttp3.Request.Builder().url(url).build()
+        client.newCall(request).execute().use { resp ->
+            val body = resp.body?.string() ?: error("empty body")
+            val regex = Regex("<td>(\\d{2}\\.\\d{2}\\.\\d{4})</td>\\s*<td>(\\d+(?:\\.\\d+)?)</td>")
+            val matches = regex.findAll(body).toList()
+            if (matches.isEmpty()) error("rates not found")
+            val current = matches.first().groupValues[2].replace(',', '.').toDouble()
+            val targetDate = from.format(formatter)
+            val old =
+                matches.find { it.groupValues[1] == targetDate }?.groupValues?.get(2)
+                    ?.replace(',', '.')?.toDouble() ?: current
+            return current to old
+        }
+    }
+}

--- a/data/src/main/kotlin/data/macro/MacroData.kt
+++ b/data/src/main/kotlin/data/macro/MacroData.kt
@@ -1,0 +1,7 @@
+package data.macro
+
+data class MacroData(
+    val brent: Double,
+    val keyRate: Double,
+    val keyRate6mAgo: Double,
+)

--- a/data/src/main/kotlin/data/macro/MacroDataSource.kt
+++ b/data/src/main/kotlin/data/macro/MacroDataSource.kt
@@ -1,0 +1,14 @@
+package data.macro
+
+import java.time.LocalDate
+
+class MacroDataSource(
+    private val brent: BrentDataSource,
+    private val key: KeyRateDataSource,
+) {
+    suspend fun fetchMacroData(date: LocalDate): MacroData {
+        val br = brent.fetchBrentPrice()
+        val (keyNow, keyPast) = key.fetchKeyRates(date)
+        return MacroData(br, keyNow, keyPast)
+    }
+}

--- a/service/src/main/kotlin/service/DcaService.kt
+++ b/service/src/main/kotlin/service/DcaService.kt
@@ -1,5 +1,6 @@
 package service
 
+import data.macro.MacroData
 import data.market.MarketData
 import service.dto.Action
 import service.dto.Portfolio
@@ -8,6 +9,7 @@ import java.time.LocalDate
 
 class DcaService(
     private val fetchMarketData: suspend () -> MarketData,
+    private val fetchMacroData: suspend (LocalDate) -> MacroData,
 ) {
     suspend fun generateReport(
         date: LocalDate,
@@ -15,12 +17,58 @@ class DcaService(
         config: StrategyConfig,
     ): String {
         val market = fetchMarketData()
+        val macro = fetchMacroData(date)
         val filters = Strategy.getFilterStatuses(market, portfolio, config)
         val actions = Strategy.evaluate(date, market, portfolio, config)
+
+        val corridor: Corridor =
+            when {
+                // 1. Extreme Risk-Off
+                macro.keyRate >= 22.0 || macro.brent <= 50.0 ->
+                    Corridor(
+                        riskLevel = "СИЛЬНЫЙ RISK-OFF",
+                        percentageStocks = "45–60 %",
+                    )
+
+                // 2. Risk-Off
+                macro.keyRate >= 18.0 ||
+                    macro.keyRate - macro.keyRate6mAgo >= 1.0 ||
+                    macro.brent <= 60.0 ->
+                    Corridor(
+                        riskLevel = "УМЕРЕННЫЙ RISK-OFF",
+                        percentageStocks = "55–65 %",
+                    )
+
+                // 3. Neutral
+                macro.keyRate in 15.0..17.99 &&
+                    macro.brent in 60.0..75.0 ->
+                    Corridor(
+                        riskLevel = "НЕЙТРАЛЬНЫЙ РЕЖИМ",
+                        percentageStocks = "60–70 %",
+                    )
+
+                // 4. Risk-On
+                macro.keyRate <= 15.0 &&
+                    macro.brent >= 75.0 &&
+                    macro.keyRate6mAgo - macro.keyRate >= 1.5 ->
+                    Corridor(
+                        riskLevel = "RISK-ON",
+                        percentageStocks = "70–80 %",
+                    )
+
+                // 5. По-умолчанию (неопределёнка)
+                else ->
+                    Corridor(
+                        riskLevel = "НЕЙТРАЛЬНЫЙ РЕЖИМ",
+                        percentageStocks = "60–70 %",
+                    )
+            }
 
         val lines =
             buildList {
                 add("price=${market.price}, Δ=${"%.1f".format(Strategy.delta(market))}%")
+                add("Уровень риска: ${corridor.riskLevel}")
+                add("Коридор акций: ${corridor.percentageStocks}")
                 addAll(filters.map { "${it.name}: ${if (it.passed) "✔" else "✘"}" })
                 if (actions.isEmpty()) add("Покупки не требуются")
                 actions.forEach { action ->
@@ -33,3 +81,8 @@ class DcaService(
         return lines.joinToString(separator = "\n")
     }
 }
+
+data class Corridor(
+    val riskLevel: String,
+    val percentageStocks: String,
+)

--- a/service/src/main/kotlin/service/di/ServiceModule.kt
+++ b/service/src/main/kotlin/service/di/ServiceModule.kt
@@ -1,10 +1,16 @@
 package service.di
 
 import data.market.MoexDataSource
+import data.macro.MacroDataSource
 import org.koin.dsl.module
 import service.DcaService
 
 val serviceModule =
     module {
-        single { DcaService { get<MoexDataSource>().fetchMarketData() } }
+        single {
+            DcaService(
+                fetchMarketData = { get<MoexDataSource>().fetchMarketData() },
+                fetchMacroData = { date -> get<MacroDataSource>().fetchMacroData(date) },
+            )
+        }
     }

--- a/service/src/test/kotlin/DcaServiceTest.kt
+++ b/service/src/test/kotlin/DcaServiceTest.kt
@@ -1,4 +1,5 @@
 import data.market.MarketData
+import data.macro.MacroData
 import service.DcaService
 import service.dto.Portfolio
 import service.dto.StrategyConfig
@@ -9,7 +10,8 @@ class DcaServiceTest {
     @Test
     fun `generate report with actions`() {
         val md = MarketData(2650.0, 3000.0, 2700.0, 28.0, 6.3, 13.0, 10.5)
-        val ds = DcaService { md }
+        val macro = MacroData(brent = 80.0, keyRate = 10.0, keyRate6mAgo = 11.0)
+        val ds = DcaService({ md }) { macro }
         val portfolio = Portfolio(700_000.0, 300_000.0, 300_000.0)
         val config = StrategyConfig()
         val text =
@@ -17,5 +19,6 @@ class DcaServiceTest {
                 ds.generateReport(java.time.LocalDate.of(2025, 6, 10), portfolio, config)
             }
         assertTrue(text.contains("DCA"))
+        assertTrue(text.contains("Коридор акций"))
     }
 }

--- a/telegram/src/test/kotlin/BotCommandHandlerTest.kt
+++ b/telegram/src/test/kotlin/BotCommandHandlerTest.kt
@@ -5,6 +5,7 @@ import data.InMemoryChatConfigRepository
 import data.market.MarketData
 import kotlinx.coroutines.runBlocking
 import service.DcaService
+import data.macro.MacroData
 import service.dto.Portfolio
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -15,7 +16,7 @@ class BotCommandHandlerTest {
     fun `set monthly flow updates config`() =
         runBlocking {
             val repo = InMemoryChatConfigRepository()
-            val ds = DcaService { MarketData(1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0) }
+            val ds = DcaService({ MarketData(1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0) }) { MacroData(70.0, 10.0, 10.5) }
             val handler = BotCommandHandler(repo, ds, "http://localhost")
             val portfolio = Portfolio(0.0, 0.0, 0.0)
             handler.handle(1, "/set_monthly_flow 150000", portfolio)
@@ -27,7 +28,7 @@ class BotCommandHandlerTest {
         runBlocking {
             val repo = InMemoryChatConfigRepository()
             val md = MarketData(2650.0, 3000.0, 2700.0, 28.0, 6.3, 13.0, 10.5)
-            val ds = DcaService { md }
+            val ds = DcaService({ md }) { MacroData(70.0, 10.0, 9.5) }
             val handler = BotCommandHandler(repo, ds, "http://localhost")
             val portfolio = Portfolio(700_000.0, 300_000.0, 300_000.0)
             val text = handler.handle(1, "/report_now", portfolio) as TextResponse
@@ -37,7 +38,8 @@ class BotCommandHandlerTest {
     @Test
     fun `open webapp returns webapp response`() = runBlocking {
         val repo = InMemoryChatConfigRepository()
-        val ds = DcaService { MarketData(1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0) }
+        val md = MarketData(2650.0, 3000.0, 2700.0, 28.0, 6.3, 13.0, 10.5)
+        val ds = DcaService({ md }) { MacroData(70.0, 10.0, 9.5) }
         val handler = BotCommandHandler(repo, ds, "http://localhost")
         val portfolio = Portfolio(0.0, 0.0, 0.0)
         val resp = handler.handle(1, "/open_webapp", portfolio)


### PR DESCRIPTION
## Summary
- fetch macro indicators like Brent and CBR key rate
- compute risk corridor based on macro data
- show corridor in generated reports
- provide DI bindings for new data sources
- update unit tests

## Testing
- `./gradlew test`
- `./gradlew build`
- `./gradlew :app:run` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6847449cbdb48322af54ae875a73a428