### PR TITLE
Implement risk corridor using macro data

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,3 +18,7 @@ tasks.named("build") {
 subprojects {
     repositories { mavenCentral() }
 }
+
+application {
+    mainClass.set("app.MainKt")
+}

--- a/data/src/main/kotlin/DataModule.kt
+++ b/data/src/main/kotlin/DataModule.kt
@@ -2,6 +2,9 @@ package data
 
 import data.market.MoexDataSource
 import data.market.MoexRepository
+import data.macro.BrentDataSource
+import data.macro.KeyRateDataSource
+import data.macro.MacroDataSource
 import kotlinx.serialization.json.Json
 import okhttp3.OkHttpClient
 import org.koin.dsl.module
@@ -16,5 +19,8 @@ val dataModule = module {
     single { Json { ignoreUnknownKeys = true } }
     single { MoexRepository(get(), get()) }
     single { MoexDataSource(get()) }
+    single { BrentDataSource(get()) }
+    single { KeyRateDataSource(get()) }
+    single { MacroDataSource(get(), get()) }
     single<ChatConfigRepository> { InMemoryChatConfigRepository() }
 }

--- a/data/src/main/kotlin/data/macro/BrentDataSource.kt
+++ b/data/src/main/kotlin/data/macro/BrentDataSource.kt
@@ -1,0 +1,16 @@
+package data.macro
+
+import okhttp3.OkHttpClient
+
+class BrentDataSource(private val client: OkHttpClient) {
+    suspend fun fetchBrentPrice(): Double {
+        val url = "https://raw.githubusercontent.com/datasets/oil-prices/master/data/brent-daily.csv"
+        val request = okhttp3.Request.Builder().url(url).build()
+        client.newCall(request).execute().use { resp ->
+            val body = resp.body?.string() ?: error("empty body")
+            val line = body.trim().lineSequence().last()
+            val price = line.substringAfter(',')
+            return price.toDouble()
+        }
+    }
+}

--- a/data/src/main/kotlin/data/macro/KeyRateDataSource.kt
+++ b/data/src/main/kotlin/data/macro/KeyRateDataSource.kt
@@ -1,0 +1,30 @@
+package data.macro
+
+import okhttp3.OkHttpClient
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+class KeyRateDataSource(private val client: OkHttpClient) {
+    private val formatter = DateTimeFormatter.ofPattern("dd.MM.yyyy")
+
+    suspend fun fetchKeyRates(date: LocalDate): Pair<Double, Double> {
+        val from = date.minusMonths(6)
+        val url =
+            "https://www.cbr.ru/eng/hd_base/KeyRate/?UniDbQuery.Posted=True&" +
+                "UniDbQuery.From=${from.format(formatter)}&" +
+                "UniDbQuery.To=${date.format(formatter)}"
+        val request = okhttp3.Request.Builder().url(url).build()
+        client.newCall(request).execute().use { resp ->
+            val body = resp.body?.string() ?: error("empty body")
+            val regex = Regex("<td>(\\d{2}\\.\\d{2}\\.\\d{4})</td>\\s*<td>(\\d+(?:\\.\\d+)?)</td>")
+            val matches = regex.findAll(body).toList()
+            if (matches.isEmpty()) error("rates not found")
+            val current = matches.first().groupValues[2].replace(',', '.').toDouble()
+            val targetDate = from.format(formatter)
+            val old =
+                matches.find { it.groupValues[1] == targetDate }?.groupValues?.get(2)
+                    ?.replace(',', '.')?.toDouble() ?: current
+            return current to old
+        }
+    }
+}

--- a/data/src/main/kotlin/data/macro/MacroData.kt
+++ b/data/src/main/kotlin/data/macro/MacroData.kt
@@ -1,0 +1,7 @@
+package data.macro
+
+data class MacroData(
+    val brent: Double,
+    val keyRate: Double,
+    val keyRate6mAgo: Double,
+)

--- a/data/src/main/kotlin/data/macro/MacroDataSource.kt
+++ b/data/src/main/kotlin/data/macro/MacroDataSource.kt
@@ -1,0 +1,14 @@
+package data.macro
+
+import java.time.LocalDate
+
+class MacroDataSource(
+    private val brent: BrentDataSource,
+    private val key: KeyRateDataSource,
+) {
+    suspend fun fetchMacroData(date: LocalDate): MacroData {
+        val br = brent.fetchBrentPrice()
+        val (keyNow, keyPast) = key.fetchKeyRates(date)
+        return MacroData(br, keyNow, keyPast)
+    }
+}

--- a/service/src/main/kotlin/service/di/ServiceModule.kt
+++ b/service/src/main/kotlin/service/di/ServiceModule.kt
@@ -1,10 +1,16 @@
 package service.di
 
 import data.market.MoexDataSource
+import data.macro.MacroDataSource
 import org.koin.dsl.module
 import service.DcaService
 
 val serviceModule =
     module {
-        single { DcaService { get<MoexDataSource>().fetchMarketData() } }
+        single {
+            DcaService(
+                fetchMarketData = { get<MoexDataSource>().fetchMarketData() },
+                fetchMacroData = { date -> get<MacroDataSource>().fetchMacroData(date) },
+            )
+        }
     }

--- a/service/src/test/kotlin/DcaServiceTest.kt
+++ b/service/src/test/kotlin/DcaServiceTest.kt
@@ -1,4 +1,5 @@
 import data.market.MarketData
+import data.macro.MacroData
 import service.DcaService
 import service.dto.Portfolio
 import service.dto.StrategyConfig
@@ -9,7 +10,8 @@ class DcaServiceTest {
     @Test
     fun `generate report with actions`() {
         val md = MarketData(2650.0, 3000.0, 2700.0, 28.0, 6.3, 13.0, 10.5)
-        val ds = DcaService { md }
+        val macro = MacroData(brent = 80.0, keyRate = 10.0, keyRate6mAgo = 11.0)
+        val ds = DcaService({ md }) { macro }
         val portfolio = Portfolio(700_000.0, 300_000.0, 300_000.0)
         val config = StrategyConfig()
         val text =
@@ -17,5 +19,6 @@ class DcaServiceTest {
                 ds.generateReport(java.time.LocalDate.of(2025, 6, 10), portfolio, config)
             }
         assertTrue(text.contains("DCA"))
+        assertTrue(text.contains("Коридор акций"))
     }
 }

--- a/telegram/src/test/kotlin/BotCommandHandlerTest.kt
+++ b/telegram/src/test/kotlin/BotCommandHandlerTest.kt
@@ -3,6 +3,7 @@ import data.InMemoryChatConfigRepository
 import data.market.MarketData
 import kotlinx.coroutines.runBlocking
 import service.DcaService
+import data.macro.MacroData
 import service.dto.Portfolio
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -13,7 +14,7 @@ class BotCommandHandlerTest {
     fun `set monthly flow updates config`() =
         runBlocking {
             val repo = InMemoryChatConfigRepository()
-            val ds = DcaService { MarketData(1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0) }
+            val ds = DcaService({ MarketData(1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0) }) { MacroData(70.0, 10.0, 10.5) }
             val handler = BotCommandHandler(repo, ds)
             val portfolio = Portfolio(0.0, 0.0, 0.0)
             handler.handle(1, "/set_monthly_flow 150000", portfolio)
@@ -25,7 +26,7 @@ class BotCommandHandlerTest {
         runBlocking {
             val repo = InMemoryChatConfigRepository()
             val md = MarketData(2650.0, 3000.0, 2700.0, 28.0, 6.3, 13.0, 10.5)
-            val ds = DcaService { md }
+            val ds = DcaService({ md }) { MacroData(70.0, 10.0, 9.5) }
             val handler = BotCommandHandler(repo, ds)
             val portfolio = Portfolio(700_000.0, 300_000.0, 300_000.0)
             val text = handler.handle(1, "/report_now", portfolio)


### PR DESCRIPTION
## Summary
- fetch macro indicators like Brent and CBR key rate
- compute risk corridor based on macro data
- show corridor in generated reports
- provide DI bindings for new data sources
- update unit tests

## Testing
- `./gradlew test`
- `./gradlew build`
- `./gradlew :app:run` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6847449cbdb48322af54ae875a73a428