### PR TITLE
Implement volatility-adjusted tranche

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,10 +5,20 @@ plugins {
     id("com.github.johnrengelman.shadow") version "8.1.1"
 }
 
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+
 group = "org.example"
 version = "1.0-SNAPSHOT"
 
 repositories { mavenCentral() }
+
+application {
+    mainClass.set("app.MainKt")
+}
+
+tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>().configureEach {
+    manifest.attributes(mapOf("Main-Class" to "app.MainKt"))
+}
 
 
 tasks.named("build") {

--- a/data/src/main/kotlin/data/market/MarketData.kt
+++ b/data/src/main/kotlin/data/market/MarketData.kt
@@ -7,5 +7,7 @@ data class MarketData(
     val rsi14: Double,
     val pe: Double,
     val dy: Double,
-    val ofzYield: Double
+    val ofzYield: Double,
+    val sigma30: Double,
 )
+

--- a/data/src/test/kotlin/MoexClientTest.kt
+++ b/data/src/test/kotlin/MoexClientTest.kt
@@ -27,5 +27,6 @@ class MoexClientTest {
         server.shutdown()
         assertEquals(2786.16, data.price)
         assertEquals(3371.06, data.max52)
+        assertEquals(0.272, data.sigma30, 0.001)
     }
 }

--- a/service/src/test/kotlin/DcaServiceTest.kt
+++ b/service/src/test/kotlin/DcaServiceTest.kt
@@ -9,7 +9,7 @@ import kotlin.test.assertTrue
 class DcaServiceTest {
     @Test
     fun `generate report with actions`() {
-        val md = MarketData(2650.0, 3000.0, 2700.0, 28.0, 6.3, 13.0, 10.5)
+        val md = MarketData(2650.0, 3000.0, 2700.0, 28.0, 6.3, 13.0, 10.5, 0.2)
         val macro = MacroData(brent = 80.0, keyRate = 10.0, keyRate6mAgo = 11.0)
         val ds = DcaService({ md }) { macro }
         val portfolio = Portfolio(700_000.0, 300_000.0, 300_000.0)

--- a/service/src/test/kotlin/StrategyTest.kt
+++ b/service/src/test/kotlin/StrategyTest.kt
@@ -1,0 +1,33 @@
+import service.Strategy
+import service.dto.StrategyConfig
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class StrategyTest {
+    private val config = StrategyConfig()
+
+    @Test
+    fun `level one tranche`() {
+        val amount = Strategy.enhancedTranche(-15.0, 0.20, config)
+        assertEquals(25000.0, amount, 1e-2)
+    }
+
+    @Test
+    fun `level two adjusted by sigma`() {
+        val amount = Strategy.enhancedTranche(-25.0, 0.30, config)
+        assertEquals(33333.33, amount, 1.0)
+    }
+
+    @Test
+    fun `clamped high tranche`() {
+        val amount = Strategy.enhancedTranche(-25.0, 0.05, config)
+        assertEquals(125000.0, amount, 1e-2)
+    }
+
+    @Test
+    fun `no tranche above threshold`() {
+        val amount = Strategy.enhancedTranche(-5.0, 0.20, config)
+        assertEquals(0.0, amount, 1e-2)
+    }
+}
+

--- a/telegram/src/test/kotlin/BotCommandHandlerTest.kt
+++ b/telegram/src/test/kotlin/BotCommandHandlerTest.kt
@@ -16,7 +16,7 @@ class BotCommandHandlerTest {
     fun `set monthly flow updates config`() =
         runBlocking {
             val repo = InMemoryChatConfigRepository()
-            val ds = DcaService({ MarketData(1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0) }) { MacroData(70.0, 10.0, 10.5) }
+            val ds = DcaService { MarketData(1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.1) }
             val handler = BotCommandHandler(repo, ds, "http://localhost")
             val portfolio = Portfolio(0.0, 0.0, 0.0)
             handler.handle(1, "/set_monthly_flow 150000", portfolio)
@@ -27,7 +27,7 @@ class BotCommandHandlerTest {
     fun `report now returns text`() =
         runBlocking {
             val repo = InMemoryChatConfigRepository()
-            val md = MarketData(2650.0, 3000.0, 2700.0, 28.0, 6.3, 13.0, 10.5)
+            val md = MarketData(2650.0, 3000.0, 2700.0, 28.0, 6.3, 13.0, 10.5, 0.2)
             val ds = DcaService({ md }) { MacroData(70.0, 10.0, 9.5) }
             val handler = BotCommandHandler(repo, ds, "http://localhost")
             val portfolio = Portfolio(700_000.0, 300_000.0, 300_000.0)


### PR DESCRIPTION
## Summary
- compute 30-day volatility when parsing market data
- add sigma30 parameter to MarketData
- adjust enhanced tranche logic using sigma30
- cover new behaviour with unit tests
- set main class for the build

## Testing
- `./gradlew test`
- `./gradlew build`
- `./gradlew :app:run -Dmoex.base=http://localhost:8000 --args="cli"` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684744d8b5708322a77f5c4317ca0458