### PR TITLE
Add report endpoint for WebApp

### DIFF
--- a/data/src/main/kotlin/data/market/CapeRepositoryImpl.kt
+++ b/data/src/main/kotlin/data/market/CapeRepositoryImpl.kt
@@ -12,17 +12,19 @@ import okhttp3.Request
 import java.net.URI
 import java.nio.file.Files
 
-private const val CapeUrl = "https://capital-gain.ru/data/IMOEX_FUNDAMENTALS.json"
+private const val CapeFile = "IMOEX_FUNDAMENTALS.json"
 
 class CapeRepositoryImpl(
     private val client: OkHttpClient,
     private val json: Json,
+    private val baseUrl: String = "https://capital-gain.ru",
 ) : CapeRepository {
     override suspend fun fetchCape(): Double =
         withContext(Dispatchers.IO) {
+            val url = "$baseUrl/data/$CapeFile"
             val body =
-                if (CapeUrl.startsWith("file:")) {
-                    val uri = URI(CapeUrl)
+                if (url.startsWith("file:")) {
+                    val uri = URI(url)
                     Files.readString(
                         java.nio.file.Path
                             .of(uri),
@@ -31,7 +33,7 @@ class CapeRepositoryImpl(
                     val request =
                         Request
                             .Builder()
-                            .url(CapeUrl)
+                            .url(url)
                             .header("Accept", "application/json")
                             .build()
                     client.newCall(request).execute().use { it.body?.string() ?: error("empty body") }

--- a/data/src/test/kotlin/MoexClientTest.kt
+++ b/data/src/test/kotlin/MoexClientTest.kt
@@ -29,8 +29,8 @@ class MoexClientTest {
         val data = dataSource.fetchMarketData()
 
         server.shutdown()
-        assertEquals(2786.16, data.price)
-        assertEquals(3371.06, data.max52)
-        assertEquals(7.0, data.cape, data.sigma30, 0.001)
+        assertEquals(2786.16, data.price, 0.01)
+        assertEquals(3371.06, data.max52, 0.01)
+        assertEquals(7.0, data.cape, 0.001)
     }
 }

--- a/service/src/test/kotlin/DcaServiceTest.kt
+++ b/service/src/test/kotlin/DcaServiceTest.kt
@@ -16,12 +16,10 @@ class DcaServiceTest {
                 sma200 = 2700.0,
                 sma50 = 2750.0,
                 rsi14 = 28.0,
-                dy = 13.0,
-                ofzYield = 10.5,
+                sigma30 = 7.0,
                 cape = 7.0,
             )
-        val ds = DcaService { md }
-        val macro = MacroData(brent = 80.0, keyRate = 10.0, keyRate6mAgo = 11.0)
+        val ds = DcaService({ md }) { MacroData(brent = 80.0, keyRate = 10.0, keyRate6mAgo = 11.0) }
         val portfolio = Portfolio(700_000.0, 300_000.0, 300_000.0)
         val config = StrategyConfig()
         val text =

--- a/service/src/test/kotlin/StrategyFilterTest.kt
+++ b/service/src/test/kotlin/StrategyFilterTest.kt
@@ -16,9 +16,8 @@ class StrategyFilterTest {
                 sma200 = 2700.0,
                 sma50 = 2760.0,
                 rsi14 = 25.0,
-                dy = 13.0,
-                ofzYield = 10.0,
                 sigma30 = 7.0,
+                cape = 7.0,
             )
         val p = Portfolio(equity = 1_000_000.0, others = 300_000.0, cushionAmount = 300_000.0)
         val cfg = StrategyConfig()

--- a/telegram/src/test/kotlin/BotCommandHandlerTest.kt
+++ b/telegram/src/test/kotlin/BotCommandHandlerTest.kt
@@ -17,18 +17,17 @@ class BotCommandHandlerTest {
         runBlocking {
             val repo = InMemoryChatConfigRepository()
             val ds =
-                DcaService {
+                DcaService({
                     MarketData(
                         price = 1.0,
                         max52 = 1.0,
                         sma200 = 1.0,
                         sma50 = 1.0,
                         rsi14 = 1.0,
-                        dy = 1.0,
-                        ofzYield = 1.0,
                         sigma30 = 1.0,
+                        cape = 1.0,
                     )
-                }
+                }) { MacroData(70.0, 10.0, 9.5) }
             val handler = BotCommandHandler(repo, ds, "http://localhost")
             val portfolio = Portfolio(0.0, 0.0, 0.0)
             handler.handle(1, "/set_monthly_flow 150000", portfolio)
@@ -46,11 +45,10 @@ class BotCommandHandlerTest {
                     sma200 = 2700.0,
                     sma50 = 2750.0,
                     rsi14 = 28.0,
-                    dy = 13.0,
-                    ofzYield = 10.5,
                     sigma30 = 7.0,
+                    cape = 7.0,
                 )
-            val ds = DcaService { md }
+            val ds = DcaService({ md }) { MacroData(70.0, 10.0, 9.5) }
             val handler = BotCommandHandler(repo, ds, "http://localhost")
             val portfolio = Portfolio(700_000.0, 300_000.0, 300_000.0)
             val text = handler.handle(1, "/report_now", portfolio) as TextResponse
@@ -61,7 +59,15 @@ class BotCommandHandlerTest {
     fun `open webapp returns webapp response`() =
         runBlocking {
             val repo = InMemoryChatConfigRepository()
-            val md = MarketData(2650.0, 3000.0, 2700.0, 28.0, 6.3, 13.0, 10.5, 0.2)
+            val md = MarketData(
+                price = 2650.0,
+                max52 = 3000.0,
+                sma200 = 2700.0,
+                sma50 = 2800.0,
+                rsi14 = 28.0,
+                sigma30 = 6.3,
+                cape = 7.0,
+            )
             val ds = DcaService({ md }) { MacroData(70.0, 10.0, 9.5) }
             val handler = BotCommandHandler(repo, ds, "http://localhost")
             val portfolio = Portfolio(0.0, 0.0, 0.0)

--- a/webapp/build.gradle.kts
+++ b/webapp/build.gradle.kts
@@ -4,6 +4,9 @@ plugins {
 
 dependencies {
     implementation(project(":service"))
+    implementation(project(":data"))
+    implementation("com.squareup.okhttp3:okhttp:4.12.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
     implementation("org.springframework.boot:spring-boot-starter-web:3.2.0")
     testImplementation("org.springframework.boot:spring-boot-starter-test:3.2.0")
     testImplementation(kotlin("test"))

--- a/webapp/src/main/kotlin/webapp/ReportController.kt
+++ b/webapp/src/main/kotlin/webapp/ReportController.kt
@@ -1,0 +1,20 @@
+package webapp
+
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+import service.DcaService
+import service.dto.Portfolio
+import service.dto.StrategyConfig
+import java.time.LocalDate
+
+@RestController
+class ReportController(
+    private val service: DcaService,
+) {
+    @GetMapping("/api/report")
+    suspend fun report(): String {
+        val portfolio = Portfolio(700_000.0, 300_000.0, 300_000.0)
+        val config = StrategyConfig()
+        return service.generateReport(LocalDate.now(), portfolio, config)
+    }
+}

--- a/webapp/src/main/kotlin/webapp/WebAppConfig.kt
+++ b/webapp/src/main/kotlin/webapp/WebAppConfig.kt
@@ -1,0 +1,49 @@
+package webapp
+
+import data.macro.BrentDataSource
+import data.macro.KeyRateDataSource
+import data.macro.MacroDataSource
+import data.market.CapeRepository
+import data.market.CapeRepositoryImpl
+import data.market.MoexDataSource
+import data.market.MoexRepository
+import kotlinx.serialization.json.Json
+import okhttp3.OkHttpClient
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import service.DcaService
+import java.time.Duration
+
+@Configuration
+class WebAppConfig {
+    @Bean
+    fun okHttpClient(): OkHttpClient = OkHttpClient.Builder()
+        .callTimeout(Duration.ofSeconds(10))
+        .build()
+
+    @Bean
+    fun json(): Json = Json { ignoreUnknownKeys = true }
+
+    @Bean
+    fun moexRepository(client: OkHttpClient, json: Json) = MoexRepository(client, json)
+
+    @Bean
+    fun capeRepository(client: OkHttpClient, json: Json): CapeRepository = CapeRepositoryImpl(client, json)
+
+    @Bean
+    fun moexDataSource(repo: MoexRepository, capeRepository: CapeRepository) = MoexDataSource(repo, capeRepository)
+
+    @Bean
+    fun brentSource(client: OkHttpClient) = BrentDataSource(client)
+
+    @Bean
+    fun keyRateSource(client: OkHttpClient) = KeyRateDataSource(client)
+
+    @Bean
+    fun macroDataSource(brentSource: BrentDataSource, keyRateSource: KeyRateDataSource) =
+        MacroDataSource(brentSource, keyRateSource)
+
+    @Bean
+    fun dcaService(market: MoexDataSource, macro: MacroDataSource) =
+        DcaService({ market.fetchMarketData() }, { date -> macro.fetchMacroData(date) })
+}

--- a/webapp/src/test/kotlin/webapp/ReportControllerTest.kt
+++ b/webapp/src/test/kotlin/webapp/ReportControllerTest.kt
@@ -1,0 +1,37 @@
+package webapp
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.context.annotation.Bean
+import org.springframework.http.HttpStatus
+import service.DcaService
+import kotlin.test.assertEquals
+import data.macro.MacroData
+import data.market.MarketData
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class ReportControllerTest {
+    @TestConfiguration
+    class Config {
+        @Bean
+        fun dcaService(): DcaService = DcaService(
+            fetchMarketData = {
+                MarketData(1000.0, 1200.0, 1100.0, 1150.0, 30.0, 5.0, 6.0)
+            },
+            fetchMacroData = { MacroData(70.0, 10.0, 9.5) }
+        )
+    }
+
+    @Autowired
+    lateinit var rest: TestRestTemplate
+
+    @Test
+    fun reportReturnsText() {
+        val response = rest.getForEntity("/api/report", String::class.java)
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assert(response.body!!.isNotEmpty())
+    }
+}


### PR DESCRIPTION
## Summary
- fix CapeRepositoryImpl constructor
- update tests to new MarketData fields
- add report endpoint and configuration
- cover report endpoint with a test

## Testing
- `./gradlew test`
- `./gradlew build`
- `./gradlew :app:run` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684855788b1c83228484ca338e897e95