### PR TITLE
Implement Telegram bot onboarding

### DIFF
--- a/data/src/main/kotlin/ChatConfig.kt
+++ b/data/src/main/kotlin/ChatConfig.kt
@@ -2,9 +2,14 @@ package data
 
 import java.time.LocalTime
 
+import data.OnboardingStage
+
 data class ChatConfig(
     var monthlyFlow: Double = 100_000.0,
     var baseDcaAmount: Double = 50_000.0,
     var minCushionRatio: Double = 3.0,
-    var reportTime: LocalTime = LocalTime.of(10, 0)
+    var reportTime: LocalTime = LocalTime.of(10, 0),
+    var onboardingStage: OnboardingStage = OnboardingStage.NONE,
+    var expenses: Double = 0.0,
+    var flow: Double = 0.0,
 )

--- a/data/src/main/kotlin/OnboardingStage.kt
+++ b/data/src/main/kotlin/OnboardingStage.kt
@@ -1,0 +1,12 @@
+package data
+
+enum class OnboardingStage {
+    NONE,
+    WAIT_START,
+    WAIT_EXPENSES,
+    WAIT_CUSHION_CONFIRM,
+    WAIT_MONTHLY_FLOW,
+    WAIT_MODEL,
+    WAIT_REPORT_TIME,
+    WAIT_PUSH
+}

--- a/data/src/main/kotlin/data/market/CapeRepositoryImpl.kt
+++ b/data/src/main/kotlin/data/market/CapeRepositoryImpl.kt
@@ -17,12 +17,13 @@ private const val CapeUrl = "https://capital-gain.ru/data/IMOEX_FUNDAMENTALS.jso
 class CapeRepositoryImpl(
     private val client: OkHttpClient,
     private val json: Json,
+    private val baseUrl: String = CapeUrl,
 ) : CapeRepository {
     override suspend fun fetchCape(): Double =
         withContext(Dispatchers.IO) {
             val body =
-                if (CapeUrl.startsWith("file:")) {
-                    val uri = URI(CapeUrl)
+                if (baseUrl.startsWith("file:")) {
+                    val uri = URI(baseUrl)
                     Files.readString(
                         java.nio.file.Path
                             .of(uri),
@@ -31,7 +32,7 @@ class CapeRepositoryImpl(
                     val request =
                         Request
                             .Builder()
-                            .url(CapeUrl)
+                            .url(baseUrl)
                             .header("Accept", "application/json")
                             .build()
                     client.newCall(request).execute().use { it.body?.string() ?: error("empty body") }

--- a/data/src/test/kotlin/MoexClientTest.kt
+++ b/data/src/test/kotlin/MoexClientTest.kt
@@ -31,6 +31,7 @@ class MoexClientTest {
         server.shutdown()
         assertEquals(2786.16, data.price)
         assertEquals(3371.06, data.max52)
-        assertEquals(7.0, data.cape, data.sigma30, 0.001)
+        assertEquals(7.0, data.cape)
+        assertEquals(0.2727, data.sigma30, 0.001)
     }
 }

--- a/service/src/test/kotlin/DcaServiceTest.kt
+++ b/service/src/test/kotlin/DcaServiceTest.kt
@@ -16,12 +16,11 @@ class DcaServiceTest {
                 sma200 = 2700.0,
                 sma50 = 2750.0,
                 rsi14 = 28.0,
-                dy = 13.0,
-                ofzYield = 10.5,
+                sigma30 = 7.0,
                 cape = 7.0,
             )
-        val ds = DcaService { md }
         val macro = MacroData(brent = 80.0, keyRate = 10.0, keyRate6mAgo = 11.0)
+        val ds = DcaService({ md }) { macro }
         val portfolio = Portfolio(700_000.0, 300_000.0, 300_000.0)
         val config = StrategyConfig()
         val text =

--- a/service/src/test/kotlin/StrategyFilterTest.kt
+++ b/service/src/test/kotlin/StrategyFilterTest.kt
@@ -16,9 +16,8 @@ class StrategyFilterTest {
                 sma200 = 2700.0,
                 sma50 = 2760.0,
                 rsi14 = 25.0,
-                dy = 13.0,
-                ofzYield = 10.0,
                 sigma30 = 7.0,
+                cape = 7.0,
             )
         val p = Portfolio(equity = 1_000_000.0, others = 300_000.0, cushionAmount = 300_000.0)
         val cfg = StrategyConfig()

--- a/telegram/src/main/kotlin/bot/BotCommandHandler.kt
+++ b/telegram/src/main/kotlin/bot/BotCommandHandler.kt
@@ -1,6 +1,7 @@
 package bot
 
 import data.ChatConfigRepository
+import data.OnboardingStage
 import service.DcaService
 import service.dto.Portfolio
 import service.utils.toStrategyConfig
@@ -18,10 +19,94 @@ class BotCommandHandler(
         portfolio: Portfolio,
         date: LocalDate = LocalDate.now(),
     ): BotResponse {
-        val parts = text.trim().split(Regex("\\s+"))
-        val command = parts.firstOrNull() ?: return TextResponse("")
-        val arg = parts.getOrNull(1)
+        val trimmed = text.trim()
         val config = repository.getConfig(chatId)
+
+        if (trimmed.equals("/start", ignoreCase = true)) {
+            config.onboardingStage = OnboardingStage.WAIT_START
+            repository.update(chatId, config)
+            return TextResponse("Привет! Это бот для DCA стратегии. Напишите \"Начать\" для настройки")
+        }
+
+        when (config.onboardingStage) {
+            OnboardingStage.WAIT_START -> {
+                if (trimmed.equals("начать", ignoreCase = true)) {
+                    config.onboardingStage = OnboardingStage.WAIT_EXPENSES
+                    repository.update(chatId, config)
+                    return TextResponse("Введите ваши ежемесячные расходы")
+                }
+                return TextResponse("Напишите \"Начать\" для продолжения")
+            }
+            OnboardingStage.WAIT_EXPENSES -> {
+                val value = trimmed.toDoubleOrNull() ?: return TextResponse("Неверный формат")
+                config.expenses = value
+                config.onboardingStage = OnboardingStage.WAIT_CUSHION_CONFIRM
+                repository.update(chatId, config)
+                val cushion = (value * 3).toLong()
+                return TextResponse("Ваша подушка = ${cushion} ₽\nВведите 'есть' если подушка готова или 'нет'")
+            }
+            OnboardingStage.WAIT_CUSHION_CONFIRM -> {
+                if (trimmed.equals("есть", true) || trimmed.equals("нет", true)) {
+                    config.onboardingStage = OnboardingStage.WAIT_MONTHLY_FLOW
+                    repository.update(chatId, config)
+                    return TextResponse("Сколько откладываете в месяц?")
+                }
+                return TextResponse("Введите 'есть' или 'нет'")
+            }
+            OnboardingStage.WAIT_MONTHLY_FLOW -> {
+                val value = trimmed.toDoubleOrNull() ?: return TextResponse("Неверный формат")
+                if (value <= 0) return TextResponse("Значение должно быть положительным")
+                config.flow = value
+                config.onboardingStage = OnboardingStage.WAIT_MODEL
+                repository.update(chatId, config)
+                return TextResponse("Выберите модель: Консервативная 40/60, Сбалансированная 50/50, Агрессивная 60/40")
+            }
+            OnboardingStage.WAIT_MODEL -> {
+                val ratio = when (trimmed.lowercase()) {
+                    "консервативная" -> 0.4
+                    "сбалансированная" -> 0.5
+                    "агрессивная" -> 0.6
+                    else -> null
+                } ?: return TextResponse("Выберите модель из списка")
+                config.monthlyFlow = config.flow
+                config.baseDcaAmount = config.monthlyFlow * ratio
+                config.onboardingStage = OnboardingStage.WAIT_REPORT_TIME
+                repository.update(chatId, config)
+                val reserve = (config.monthlyFlow - config.baseDcaAmount).toLong()
+                val dca = config.baseDcaAmount.toLong()
+                return TextResponse("DCA = ${dca} ₽, Резерв = ${reserve} ₽\nВо сколько проверять рынок? (по умолчанию 10:00)")
+            }
+            OnboardingStage.WAIT_REPORT_TIME -> {
+                val time = if (trimmed.isEmpty()) {
+                    LocalTime.of(10, 0)
+                } else {
+                    try {
+                        LocalTime.parse(trimmed)
+                    } catch (_: Exception) {
+                        return TextResponse("Неверный формат времени")
+                    }
+                }
+                config.reportTime = time
+                config.onboardingStage = OnboardingStage.WAIT_PUSH
+                repository.update(chatId, config)
+                return TextResponse("Включить push-уведомления? да/нет")
+            }
+            OnboardingStage.WAIT_PUSH -> {
+                if (trimmed.equals("да", true) || trimmed.equals("нет", true)) {
+                    config.onboardingStage = OnboardingStage.NONE
+                    repository.update(chatId, config)
+                    return TextResponse("Настройка завершена")
+                }
+                return TextResponse("Ответьте да или нет")
+            }
+            OnboardingStage.NONE -> {}
+        }
+
+        if (!trimmed.startsWith("/")) return TextResponse("Неизвестная команда")
+
+        val parts = trimmed.split(Regex("\\s+"))
+        val command = parts.first()
+        val arg = parts.getOrNull(1)
         return when (command) {
             "/set_monthly_flow" -> {
                 val value = arg?.toDoubleOrNull() ?: return TextResponse("Неверный формат")

--- a/telegram/src/test/kotlin/BotCommandHandlerTest.kt
+++ b/telegram/src/test/kotlin/BotCommandHandlerTest.kt
@@ -16,19 +16,8 @@ class BotCommandHandlerTest {
     fun `set monthly flow updates config`() =
         runBlocking {
             val repo = InMemoryChatConfigRepository()
-            val ds =
-                DcaService {
-                    MarketData(
-                        price = 1.0,
-                        max52 = 1.0,
-                        sma200 = 1.0,
-                        sma50 = 1.0,
-                        rsi14 = 1.0,
-                        dy = 1.0,
-                        ofzYield = 1.0,
-                        sigma30 = 1.0,
-                    )
-                }
+            val md = MarketData(1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0)
+            val ds = DcaService({ md }) { MacroData(1.0, 1.0, 1.0) }
             val handler = BotCommandHandler(repo, ds, "http://localhost")
             val portfolio = Portfolio(0.0, 0.0, 0.0)
             handler.handle(1, "/set_monthly_flow 150000", portfolio)
@@ -46,11 +35,10 @@ class BotCommandHandlerTest {
                     sma200 = 2700.0,
                     sma50 = 2750.0,
                     rsi14 = 28.0,
-                    dy = 13.0,
-                    ofzYield = 10.5,
                     sigma30 = 7.0,
+                    cape = 7.0,
                 )
-            val ds = DcaService { md }
+            val ds = DcaService({ md }) { MacroData(70.0, 10.0, 9.5) }
             val handler = BotCommandHandler(repo, ds, "http://localhost")
             val portfolio = Portfolio(700_000.0, 300_000.0, 300_000.0)
             val text = handler.handle(1, "/report_now", portfolio) as TextResponse
@@ -61,7 +49,7 @@ class BotCommandHandlerTest {
     fun `open webapp returns webapp response`() =
         runBlocking {
             val repo = InMemoryChatConfigRepository()
-            val md = MarketData(2650.0, 3000.0, 2700.0, 28.0, 6.3, 13.0, 10.5, 0.2)
+            val md = MarketData(2650.0, 3000.0, 2700.0, 6.3, 28.0, 0.2, 7.0)
             val ds = DcaService({ md }) { MacroData(70.0, 10.0, 9.5) }
             val handler = BotCommandHandler(repo, ds, "http://localhost")
             val portfolio = Portfolio(0.0, 0.0, 0.0)

--- a/telegram/src/test/kotlin/OnboardingTest.kt
+++ b/telegram/src/test/kotlin/OnboardingTest.kt
@@ -1,0 +1,49 @@
+import bot.BotCommandHandler
+import bot.TextResponse
+import data.InMemoryChatConfigRepository
+import data.OnboardingStage
+import data.macro.MacroData
+import data.market.MarketData
+import kotlinx.coroutines.runBlocking
+import service.DcaService
+import service.dto.Portfolio
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class OnboardingTest {
+    private fun handler(): BotCommandHandler {
+        val md = MarketData(1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0)
+        val ds = DcaService({ md }) { MacroData(1.0, 1.0, 1.0) }
+        val repo = InMemoryChatConfigRepository()
+        return BotCommandHandler(repo, ds, "http://localhost")
+    }
+
+    @Test
+    fun `start sets state`() = runBlocking {
+        val repo = InMemoryChatConfigRepository()
+        val md = MarketData(1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0)
+        val ds = DcaService({ md }) { MacroData(1.0, 1.0, 1.0) }
+        val handler = BotCommandHandler(repo, ds, "http://localhost")
+        val p = Portfolio(0.0, 0.0, 0.0)
+        val resp = handler.handle(1, "/start", p) as TextResponse
+        assertTrue(resp.text.contains("бот"))
+        assertEquals(OnboardingStage.WAIT_START, repo.getConfig(1).onboardingStage)
+    }
+
+    @Test
+    fun `expenses step`() = runBlocking {
+        val repo = InMemoryChatConfigRepository()
+        val md = MarketData(1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0)
+        val ds = DcaService({ md }) { MacroData(1.0, 1.0, 1.0) }
+        val handler = BotCommandHandler(repo, ds, "http://localhost")
+        val p = Portfolio(0.0, 0.0, 0.0)
+        handler.handle(1, "/start", p)
+        val resp = handler.handle(1, "Начать", p) as TextResponse
+        assertTrue(resp.text.contains("расходы"))
+        assertEquals(OnboardingStage.WAIT_EXPENSES, repo.getConfig(1).onboardingStage)
+        val resp2 = handler.handle(1, "50000", p) as TextResponse
+        assertTrue(resp2.text.contains("подушка"))
+        assertEquals(OnboardingStage.WAIT_CUSHION_CONFIRM, repo.getConfig(1).onboardingStage)
+    }
+}


### PR DESCRIPTION
## Summary
- add `OnboardingStage` and extend `ChatConfig`
- implement onboarding workflow in `BotCommandHandler`
- update repository tests to new API
- add onboarding tests

## Testing
- `./gradlew test`
- `./gradlew build`
- `./gradlew :app:run` *(fails: UnknownHostException)*

------
https://chatgpt.com/codex/tasks/task_e_68486415b4408322aa332fb407a55fe4